### PR TITLE
Tweak the buffers' auto-reallocation mechanism

### DIFF
--- a/sources/barray/barray_auto_expand.c
+++ b/sources/barray/barray_auto_expand.c
@@ -3,5 +3,5 @@
 
 int barray_auto_expand(ByteArray *b)
 {
-    return barray_reserve(b, b->maxSize + ft_maxu(2 * ft_sqrtu(b->maxSize + 1) + 1, BARRAY_MIN_BYTE_ALLOC));
+    return barray_reserve(b, b->maxSize + ft_maxu(3 * b->maxSize / 2 + 1, BARRAY_MIN_BYTE_ALLOC));
 }

--- a/sources/vector/vector_auto_expand.c
+++ b/sources/vector/vector_auto_expand.c
@@ -5,5 +5,5 @@ int vector_auto_expand(Vector *vec)
 {
     size_t minAllocs = (VECTOR_MIN_BYTE_ALLOC - 1) / vec->itemSize + 1;
 
-    return vector_reserve(vec, vec->maxItemCount + ft_maxu(2 * ft_sqrtu(vec->maxItemCount) + 1, minAllocs));
+    return vector_reserve(vec, vec->maxItemCount + ft_maxu(3 * vec->maxItemCount / 2 + 1, minAllocs));
 }


### PR DESCRIPTION
Use exponential growth rather than quadratic growth to limit memory allocations and copy operations.